### PR TITLE
Test saga coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple Sagas
 
+[![Build Status](https://travis-ci.com/simplesourcing/simplesagas.svg?branch=master)](https://travis-ci.com/simplesourcing/simplesagas)
+
 ## Caveat
 
 ***Please note:** This repo is **experimental***.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,6 +45,7 @@
     <modules>
         <module>simplesaga-model</module>
         <module>simplesaga-shared</module>
+        <module>simplesaga-dsl</module>
         <module>simplesaga-action</module>
         <module>simplesaga-http</module>
         <module>simplesaga-saga</module>

--- a/java/simplesaga-dsl/pom.xml
+++ b/java/simplesaga-dsl/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>simplesaga-parent</artifactId>
+        <groupId>io.simplesource</groupId>
+        <version>0.2.3-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>simplesaga-dsl</artifactId>
+
+    <dependencies>
+
+        <!-- Simple Sagas -->
+        <dependency>
+            <groupId>io.simplesource</groupId>
+            <artifactId>simplesaga-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.simplesource</groupId>
+            <artifactId>simplesaga-shared</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/java/simplesaga-dsl/src/main/java/io/simplesource/saga/dsl/SagaDsl.java
+++ b/java/simplesaga-dsl/src/main/java/io/simplesource/saga/dsl/SagaDsl.java
@@ -1,4 +1,4 @@
-package io.simplesource.saga.saga.dsl;
+package io.simplesource.saga.dsl;
 
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;

--- a/java/simplesaga-dsl/src/test/java/io/simplesource/saga/dsl/DslTest.java
+++ b/java/simplesaga-dsl/src/test/java/io/simplesource/saga/dsl/DslTest.java
@@ -1,4 +1,4 @@
-package io.simplesource.saga.saga.dsl;
+package io.simplesource.saga.dsl;
 
 import java.util.Collections;
 import java.util.Set;
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import io.simplesource.data.NonEmptyList;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static io.simplesource.saga.saga.dsl.SagaDsl.*;
+import static io.simplesource.saga.dsl.SagaDsl.*;
 
 import io.simplesource.saga.model.action.ActionCommand;
 import io.simplesource.saga.model.saga.Saga;

--- a/java/simplesaga-saga/pom.xml
+++ b/java/simplesaga-saga/pom.xml
@@ -30,6 +30,35 @@
             <artifactId>simplesaga-shared</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.simplesource</groupId>
+            <artifactId>simplesaga-testutils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.simplesource</groupId>
+            <artifactId>simplesaga-serialization</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.simplesource</groupId>
+            <artifactId>simplesaga-dsl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Avro -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
         <!-- Kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -61,4 +90,28 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>idl-protocol</goal>
+                        </goals>
+
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+                            <testSourceDirectory>${project.basedir}/src/test/avro</testSourceDirectory>
+                            <stringType>String</stringType>
+                            <enableDecimalLogicalType>true</enableDecimalLogicalType>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/SagaApp.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/SagaApp.java
@@ -1,26 +1,24 @@
 package io.simplesource.saga.saga;
 
-import io.simplesource.saga.model.messages.ActionResponse;
-import io.simplesource.saga.model.messages.SagaRequest;
-import io.simplesource.saga.model.messages.SagaResponse;
-import io.simplesource.saga.model.messages.SagaStateTransition;
-import io.simplesource.saga.model.saga.Saga;
-import io.simplesource.saga.model.serdes.SagaSerdes;
 import io.simplesource.saga.model.specs.ActionProcessorSpec;
 import io.simplesource.saga.model.specs.SagaSpec;
-import io.simplesource.saga.saga.app.*;
-import io.simplesource.saga.shared.topics.*;
+import io.simplesource.saga.saga.app.SagaContext;
+import io.simplesource.saga.saga.app.SagaCoordinatorTopologyBuilder;
+import io.simplesource.saga.saga.app.SagaStream;
+import io.simplesource.saga.shared.topics.TopicConfig;
+import io.simplesource.saga.shared.topics.TopicConfigBuilder;
+import io.simplesource.saga.shared.topics.TopicCreation;
+import io.simplesource.saga.shared.topics.TopicTypes;
 import io.simplesource.saga.shared.utils.StreamAppConfig;
 import io.simplesource.saga.shared.utils.StreamAppUtils;
-import lombok.Value;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.kstream.KStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -42,27 +40,13 @@ import java.util.concurrent.TimeUnit;
  */
 final public class SagaApp<A> {
 
-    @Value
-    private final static class ActionProcessorInput<A> {
-        public final StreamsBuilder builder;
-        public final KStream<UUID, SagaRequest<A>> sagaRequest;
-        public final KStream<UUID, Saga<A>> sagaState;
-        public final KStream<UUID, SagaStateTransition> sagaStateTransition;
-    }
-
-    private interface ActionProcessor<A> {
-        void apply(ActionProcessorInput<A> input);
-    }
-
     private static Logger logger = LoggerFactory.getLogger(SagaApp.class);
     private final SagaSpec<A> sagaSpec;
-    private final SagaSerdes<A> serdes;
     private final TopicConfig sagaTopicConfig;
-    private final List<ActionProcessor<A>> actionProcessors = new ArrayList<>();
+    private final SagaCoordinatorTopologyBuilder<A> topologyBuilder;
     private final List<TopicCreation> topics;
 
     public SagaApp(SagaSpec<A> sagaSpec, TopicConfigBuilder.BuildSteps topicBuildFn) {
-        serdes = sagaSpec.serdes;
         this.sagaSpec = sagaSpec;
         sagaTopicConfig = TopicConfigBuilder.buildTopics(
                 TopicTypes.SagaTopic.all,
@@ -72,24 +56,18 @@ final public class SagaApp<A> {
                         org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_COMPACT
                 )),
                 topicBuildFn);
-
+        topologyBuilder = new SagaCoordinatorTopologyBuilder<>(sagaSpec, sagaTopicConfig);
         topics = TopicCreation.allTopics(sagaTopicConfig);
     }
 
     public SagaApp<A> addActionProcessor(ActionProcessorSpec<A> actionSpec, TopicConfigBuilder.BuildSteps buildFn) {
         TopicConfig topicConfig = TopicConfigBuilder.buildTopics(TopicTypes.ActionTopic.all, Collections.emptyMap(), Collections.emptyMap(), buildFn);
-
-        ActionProcessor<A> actionProcessor = input -> {
-            SagaContext<A> ctx = new SagaContext<>(sagaSpec, actionSpec, sagaTopicConfig.namer, topicConfig.namer);
-            KStream<UUID, ActionResponse> actionResponse = SagaConsumer.actionResponse(actionSpec, topicConfig.namer, input.builder);
-            SagaStream.addSubTopology(ctx,
-                    input.sagaRequest,
-                    input.sagaStateTransition,
-                    input.sagaState,
-                    actionResponse);
-        };
-        actionProcessors.add(actionProcessor);
         topics.addAll(TopicCreation.allTopics(topicConfig));
+
+        topologyBuilder.onBuildTopology((topologyContext) -> {
+            SagaContext<A> saga = new SagaContext<>(sagaSpec, actionSpec, sagaTopicConfig.namer, topicConfig.namer);
+            SagaStream.addSubTopology(topologyContext, saga);
+        });
         return this;
     }
 
@@ -107,29 +85,12 @@ final public class SagaApp<A> {
         } catch (Exception e) {
             throw new RuntimeException("Unable to add missing topics", e);
         }
-
-        StreamsBuilder builder = new StreamsBuilder();
-        // get input topic streams
-        TopicNamer topicNamer = sagaTopicConfig.namer;
-        KStream<UUID, SagaRequest<A>> sagaRequest = SagaConsumer.sagaRequest(sagaSpec, topicNamer, builder);
-        KStream<UUID, Saga<A>> sagaState = SagaConsumer.state(sagaSpec, topicNamer, builder);
-        KStream<UUID, SagaStateTransition> sagaStateTransition = SagaConsumer.stateTransition(sagaSpec, topicNamer, builder);
-        ActionProcessorInput<A> actionProcessorInput = new ActionProcessorInput<>(builder, sagaRequest, sagaState, sagaStateTransition);
-        actionProcessors.forEach(p -> p.apply(actionProcessorInput));
-
-        DistributorContext<SagaResponse> distCtx = new DistributorContext<>(
-                new DistributorSerdes<>(serdes.uuid(), serdes.response()),
-                sagaTopicConfig.namer.apply(TopicTypes.SagaTopic.responseTopicMap),
-                sagaSpec.responseWindow,
-                response -> response.sagaId);
-
-        KStream<UUID, String> topicNames = ResultDistributor.resultTopicMapStream(distCtx, builder);
-        KStream<UUID, SagaResponse> sagaResponse = SagaConsumer.sagaResponse(sagaSpec, topicNamer, builder);
-        ResultDistributor.distribute(distCtx, sagaResponse, topicNames);
-
-        // build the topology
-        Topology topology = builder.build();
+        Topology topology = buildTopology();
         logger.info("Topology description {}", topology.describe());
         StreamAppUtils.runStreamApp(config, topology);
+    }
+
+    Topology buildTopology() {
+        return topologyBuilder.build();
     }
 }

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaConsumer.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaConsumer.java
@@ -17,39 +17,39 @@ import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
-public final class SagaConsumer {
+final class SagaConsumer {
 
-    public static <A> KStream<UUID, SagaRequest<A>> sagaRequest(SagaSpec<A> spec,
-                                                                TopicNamer sagaTopicNamer,
-                                                                StreamsBuilder builder) {
+    static <A> KStream<UUID, SagaRequest<A>> sagaRequest(SagaSpec<A> spec,
+                                                         TopicNamer sagaTopicNamer,
+                                                         StreamsBuilder builder) {
         return builder.stream(sagaTopicNamer.apply(TopicTypes.SagaTopic.request),
                 Consumed.with(spec.serdes.uuid(), spec.serdes.request()));
     }
 
-    public static <A> KStream<UUID, SagaResponse> sagaResponse(SagaSpec<A> spec,
-                                                               TopicNamer sagaTopicNamer,
-                                                               StreamsBuilder builder) {
+    static <A> KStream<UUID, SagaResponse> sagaResponse(SagaSpec<A> spec,
+                                                        TopicNamer sagaTopicNamer,
+                                                        StreamsBuilder builder) {
         return builder.stream(sagaTopicNamer.apply(TopicTypes.SagaTopic.response),
                 Consumed.with(spec.serdes.uuid(), spec.serdes.response()));
     }
 
-    public static <A> KStream<UUID, SagaStateTransition> stateTransition(SagaSpec<A> spec,
-                                                                            TopicNamer sagaTopicNamer,
-                                                                            StreamsBuilder builder) {
+    static <A> KStream<UUID, SagaStateTransition> stateTransition(SagaSpec<A> spec,
+                                                                  TopicNamer sagaTopicNamer,
+                                                                  StreamsBuilder builder) {
         return builder.stream(sagaTopicNamer.apply(TopicTypes.SagaTopic.stateTransition),
                 Consumed.with(spec.serdes.uuid(), spec.serdes.transition()));
     }
 
-    public static <A> KStream<UUID, Saga<A>> state(SagaSpec<A> spec,
-                                                   TopicNamer sagaTopicNamer,
-                                                   StreamsBuilder builder) {
+    static <A> KStream<UUID, Saga<A>> state(SagaSpec<A> spec,
+                                            TopicNamer sagaTopicNamer,
+                                            StreamsBuilder builder) {
         return builder.stream(sagaTopicNamer.apply(TopicTypes.SagaTopic.state),
                 Consumed.with(spec.serdes.uuid(), spec.serdes.state()));
     }
 
-    public static <A> KStream<UUID, ActionResponse> actionResponse(ActionProcessorSpec<A> actionSpec,
-                                                                   TopicNamer topicNamer,
-                                                                   StreamsBuilder builder) {
+    static <A> KStream<UUID, ActionResponse> actionResponse(ActionProcessorSpec<A> actionSpec,
+                                                            TopicNamer topicNamer,
+                                                            StreamsBuilder builder) {
         return builder.stream(topicNamer.apply(TopicTypes.ActionTopic.response),
                 Consumed.with(actionSpec.serdes.uuid(), actionSpec.serdes.response()));
     }

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaCoordinatorTopologyBuilder.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaCoordinatorTopologyBuilder.java
@@ -1,0 +1,69 @@
+package io.simplesource.saga.saga.app;
+
+import io.simplesource.saga.model.messages.SagaRequest;
+import io.simplesource.saga.model.messages.SagaResponse;
+import io.simplesource.saga.model.messages.SagaStateTransition;
+import io.simplesource.saga.model.saga.Saga;
+import io.simplesource.saga.model.specs.SagaSpec;
+import io.simplesource.saga.shared.topics.TopicConfig;
+import io.simplesource.saga.shared.topics.TopicNamer;
+import io.simplesource.saga.shared.topics.TopicTypes;
+import lombok.Value;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class SagaCoordinatorTopologyBuilder<A> {
+
+    private final SagaSpec<A> sagaSpec;
+    private final TopicConfig sagaTopicConfig;
+    private final List<Consumer<SagaTopologyContext<A>>> onBuildConsumers = new ArrayList<>();
+
+    @Value
+    public static final class SagaTopologyContext<A> {
+        public final StreamsBuilder builder;
+        public final KStream<UUID, SagaRequest<A>> sagaRequest;
+        public final KStream<UUID, Saga<A>> sagaState;
+        public final KStream<UUID, SagaStateTransition> sagaStateTransition;
+    }
+
+    public SagaCoordinatorTopologyBuilder(SagaSpec<A> sagaSpec, TopicConfig sagaTopicConfig) {
+        this.sagaSpec = sagaSpec;
+        this.sagaTopicConfig = sagaTopicConfig;
+    }
+
+    /**
+     * Register a consumer to be called when the topology is built, ie. to allow sub-topologies to be added.
+     * @param consumer to register.
+     */
+    public void onBuildTopology(Consumer<SagaTopologyContext<A>> consumer) {
+        onBuildConsumers.add(consumer);
+    }
+
+    public Topology build() {
+        StreamsBuilder builder = new StreamsBuilder();
+        // get input topic streams
+        TopicNamer topicNamer = sagaTopicConfig.namer;
+        KStream<UUID, SagaRequest<A>> sagaRequest = SagaConsumer.sagaRequest(sagaSpec, topicNamer, builder);
+        KStream<UUID, Saga<A>> sagaState = SagaConsumer.state(sagaSpec, topicNamer, builder);
+        KStream<UUID, SagaStateTransition> sagaStateTransition = SagaConsumer.stateTransition(sagaSpec, topicNamer, builder);
+        SagaTopologyContext<A> topologyContext = new SagaTopologyContext<>(builder, sagaRequest, sagaState, sagaStateTransition);
+        onBuildConsumers.forEach(p -> p.accept(topologyContext));
+
+        DistributorContext<SagaResponse> distCtx = new DistributorContext<>(
+                new DistributorSerdes<>(sagaSpec.serdes().uuid(), sagaSpec.serdes().response()),
+                sagaTopicConfig.namer.apply(TopicTypes.SagaTopic.responseTopicMap),
+                sagaSpec.responseWindow,
+                response -> response.sagaId);
+
+        KStream<UUID, String> topicNames = ResultDistributor.resultTopicMapStream(distCtx, builder);
+        KStream<UUID, SagaResponse> sagaResponse = SagaConsumer.sagaResponse(sagaSpec, topicNamer, builder);
+        ResultDistributor.distribute(distCtx, sagaResponse, topicNames);
+        return builder.build();
+    }
+}

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaProducer.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaProducer.java
@@ -10,28 +10,25 @@ import io.simplesource.saga.shared.topics.TopicTypes;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 
-
 final class SagaProducer {
 
-    public static <A> void actionRequests(SagaContext<A> ctx, KStream<UUID, ActionRequest<A>> actionRequests) {
+    static <A> void publishActionRequests(SagaContext<A> ctx, KStream<UUID, ActionRequest<A>> actionRequests) {
         actionRequests
                 .to(ctx.actionTopicNamer.apply(TopicTypes.ActionTopic.request),
                         Produced.with(ctx.aSerdes.uuid(), ctx.aSerdes.request()));
     }
 
-    public static <A> void sagaState(SagaContext<A> ctx, KStream<UUID, Saga<A>> sagaState) {
+    static <A> void publishSagaState(SagaContext<A> ctx, KStream<UUID, Saga<A>> sagaState) {
         sagaState.to(ctx.sagaTopicNamer.apply(TopicTypes.SagaTopic.state),
                 Produced.with(ctx.sSerdes.uuid(), ctx.sSerdes.state()));
     }
 
-    public static <A> void sagaStateTransitions(SagaContext<A> ctx, KStream<UUID, SagaStateTransition>... transitions) {
-        for (KStream<UUID, SagaStateTransition> t : transitions) {
-            t.to(ctx.sagaTopicNamer.apply(TopicTypes.SagaTopic.stateTransition),
-                    Produced.with(ctx.sSerdes.uuid(), ctx.sSerdes.transition()));
-        }
+    static <A> void publishSagaStateTransitions(SagaContext<A> ctx, KStream<UUID, SagaStateTransition> transitions) {
+        transitions.to(ctx.sagaTopicNamer.apply(TopicTypes.SagaTopic.stateTransition),
+                Produced.with(ctx.sSerdes.uuid(), ctx.sSerdes.transition()));
     }
 
-    public static <A> void sagaResponses(SagaContext<A> ctx, KStream<UUID, SagaResponse> sagaResponse) {
+    static <A> void publishSagaResponses(SagaContext<A> ctx, KStream<UUID, SagaResponse> sagaResponse) {
         sagaResponse.to(ctx.sagaTopicNamer.apply(TopicTypes.SagaTopic.response),
                 Produced.with(ctx.sSerdes.uuid(), ctx.sSerdes.response()));
     }

--- a/java/simplesaga-saga/src/test/avro/TestSchemas.avdl
+++ b/java/simplesaga-saga/src/test/avro/TestSchemas.avdl
@@ -1,0 +1,24 @@
+@namespace("io.simplesource.saga.saga.avro.generated.test")
+protocol Schemas {
+  record User {
+    string firstName;
+    string lastName;
+    int yearOfBirth;
+  }
+
+  record CreateAccount {
+    string id;
+    string userName;
+  }
+
+  record AddFunds {
+    string id;
+    double amount;
+  }
+
+  record TransferFunds {
+    string fromId;
+    string toId;
+    double amount;
+  }
+}

--- a/java/simplesaga-saga/src/test/java/io/simplesource/saga/saga/SagaStreamTests.java
+++ b/java/simplesaga-saga/src/test/java/io/simplesource/saga/saga/SagaStreamTests.java
@@ -1,0 +1,634 @@
+package io.simplesource.saga.saga;
+
+import io.simplesource.data.NonEmptyList;
+import io.simplesource.data.Result;
+import io.simplesource.kafka.spec.WindowSpec;
+import io.simplesource.saga.dsl.SagaDsl;
+import io.simplesource.saga.model.action.ActionCommand;
+import io.simplesource.saga.model.action.ActionStatus;
+import io.simplesource.saga.model.messages.*;
+import io.simplesource.saga.model.saga.Saga;
+import io.simplesource.saga.model.saga.SagaError;
+import io.simplesource.saga.model.saga.SagaStatus;
+import io.simplesource.saga.model.serdes.ActionSerdes;
+import io.simplesource.saga.model.serdes.SagaSerdes;
+import io.simplesource.saga.model.specs.ActionProcessorSpec;
+import io.simplesource.saga.model.specs.SagaSpec;
+import io.simplesource.saga.saga.avro.generated.test.AddFunds;
+import io.simplesource.saga.saga.avro.generated.test.CreateAccount;
+import io.simplesource.saga.saga.avro.generated.test.TransferFunds;
+import io.simplesource.saga.serialization.avro.AvroSerdes;
+import io.simplesource.saga.shared.topics.TopicNamer;
+import io.simplesource.saga.shared.topics.TopicTypes;
+import io.simplesource.saga.testutils.*;
+import lombok.Value;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.streams.Topology;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.simplesource.saga.dsl.SagaDsl.inParallel;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SagaStreamTests {
+
+    private static String SCHEMA_URL = "http://localhost:8081/";
+
+    @Value
+    private static class SagaCoordinatorContext {
+        final TestContext testContext;
+        // serdes
+        final SagaSerdes<SpecificRecord> sagaSerdes = AvroSerdes.Specific.sagaSerdes(SCHEMA_URL, true);
+        final ActionSerdes<SpecificRecord> actionSerdes = AvroSerdes.Specific.actionSerdes(SCHEMA_URL, true);
+
+        // publishers
+        final RecordPublisher<UUID, SagaRequest<SpecificRecord>> sagaRequestPublisher;
+        final RecordPublisher<UUID, ActionResponse> actionResponsePublisher;
+
+        // verifiers
+        final RecordVerifier<UUID, ActionRequest<SpecificRecord>> actionRequestVerifier;
+        final RecordVerifier<UUID, SagaStateTransition> sagaStateTransitionVerifier;
+        final RecordVerifier<UUID, Saga<SpecificRecord>> sagaStateVerifier;
+        final RecordVerifier<UUID, SagaResponse> sagaResponseVerifier;
+
+        SagaCoordinatorContext() {
+            TopicNamer sagaTopicNamer = TopicNamer.forPrefix(Constants.sagaTopicPrefix, Constants.sagaBaseName);
+            TopicNamer actionTopicNamer = TopicNamer.forPrefix(Constants.actionTopicPrefix, Constants.sagaActionBaseName);
+
+            SagaApp<SpecificRecord> sagaApp = new SagaApp<>(
+                    new SagaSpec<>(sagaSerdes, new WindowSpec(60)),
+                    TopicUtils.buildSteps(Constants.sagaTopicPrefix, Constants.sagaBaseName));
+            sagaApp.addActionProcessor(
+                    new ActionProcessorSpec<>(actionSerdes),
+                    TopicUtils.buildSteps(Constants.actionTopicPrefix, Constants.sagaActionBaseName));
+
+            Topology topology = sagaApp.buildTopology();
+            testContext = TestContextBuilder.of(topology).build();
+
+            sagaRequestPublisher = testContext.publisher(
+                    sagaTopicNamer.apply(TopicTypes.SagaTopic.request),
+                    sagaSerdes.uuid(),
+                    sagaSerdes.request());
+            actionResponsePublisher = testContext.publisher(
+                    actionTopicNamer.apply(TopicTypes.ActionTopic.response),
+                    actionSerdes.uuid(),
+                    actionSerdes.response());
+
+            actionRequestVerifier = testContext.verifier(
+                    actionTopicNamer.apply(TopicTypes.ActionTopic.request),
+                    actionSerdes.uuid(),
+                    actionSerdes.request());
+            sagaStateTransitionVerifier = testContext.verifier(
+                    sagaTopicNamer.apply(TopicTypes.SagaTopic.stateTransition),
+                    sagaSerdes.uuid(),
+                    sagaSerdes.transition());
+            sagaStateVerifier = testContext.verifier(
+                    sagaTopicNamer.apply(TopicTypes.SagaTopic.state),
+                    sagaSerdes.uuid(),
+                    sagaSerdes.state());
+            sagaResponseVerifier = testContext.verifier(
+                    sagaTopicNamer.apply(TopicTypes.SagaTopic.response),
+                    sagaSerdes.uuid(),
+                    sagaSerdes.response());
+
+        }
+    }
+
+    private UUID action1 = UUID.randomUUID();
+    private UUID action2 = UUID.randomUUID();
+    private UUID createAccountId1 = UUID.randomUUID();
+    private UUID createAccountId2 = UUID.randomUUID();
+    private UUID addFundsId1 = UUID.randomUUID();
+    private UUID undoFundsId1 = UUID.randomUUID();
+    private UUID addFundsId2 = UUID.randomUUID();
+    private UUID undoFundsId2 = UUID.randomUUID();
+    private UUID transferId = UUID.randomUUID();
+    private UUID undoTransferId = UUID.randomUUID();
+
+    Saga<SpecificRecord> getBasicSaga() {
+        SagaDsl.SagaBuilder<SpecificRecord> builder = SagaDsl.SagaBuilder.create();
+
+        SagaDsl.SubSaga<SpecificRecord> createAccount = builder.addAction(
+                action1,
+                "createAccount",
+                new ActionCommand<>(createAccountId1, new CreateAccount("id1", "User 1")));
+
+        SagaDsl.SubSaga<SpecificRecord> addFunds = builder.addAction(
+                action2,
+                "addFunds",
+                new ActionCommand<>(addFundsId1, new AddFunds("id1", 1000.0)),
+                // this will never undo since it's in the last sub-saga
+                new ActionCommand<>(undoFundsId1, new AddFunds("id1", -1000.0)));
+
+        createAccount.andThen(addFunds);
+
+        Result<SagaError, Saga<SpecificRecord>> sagaBuildResult = builder.build();
+        assertThat(sagaBuildResult.isSuccess()).isEqualTo(true);
+
+        return sagaBuildResult.getOrElse(null);
+    }
+
+    Saga<SpecificRecord> getSagaWithUndo() {
+        SagaDsl.SagaBuilder<SpecificRecord> builder = SagaDsl.SagaBuilder.create();
+
+        SagaDsl.SubSaga<SpecificRecord> addFunds = builder.addAction(
+                action1,
+                "addFunds",
+                new ActionCommand<>(addFundsId1, new AddFunds("id1", 1000.0)),
+                new ActionCommand<>(undoFundsId1, new AddFunds("id1", -1000.0)));
+
+        SagaDsl.SubSaga<SpecificRecord> transferFunds = builder.addAction(
+                action2,
+                "transferFunds",
+                new ActionCommand<>(transferId, new TransferFunds("id1", "id2", 50.0)),
+                new ActionCommand<>(undoTransferId, new TransferFunds("id2", "id1", -50.0)));
+
+        addFunds.andThen(transferFunds);
+
+        Result<SagaError, Saga<SpecificRecord>> sagaBuildResult = builder.build();
+        assertThat(sagaBuildResult.isSuccess()).isEqualTo(true);
+
+        return sagaBuildResult.getOrElse(null);
+    }
+
+    Saga<SpecificRecord> getParallelSaga() {
+        SagaDsl.SagaBuilder<SpecificRecord> builder = SagaDsl.SagaBuilder.create();
+
+        SagaDsl.SubSaga<SpecificRecord> addFunds1 = builder.addAction(
+                action1,
+                "addFunds",
+                new ActionCommand<>(addFundsId1, new AddFunds("id1", 1000.0)),
+                new ActionCommand<>(undoFundsId1, new AddFunds("id1", -1000.0)));
+        SagaDsl.SubSaga<SpecificRecord> addFunds2 = builder.addAction(
+                action2,
+                "addFunds",
+                new ActionCommand<>(addFundsId2, new AddFunds("id2", 1000.0)),
+                new ActionCommand<>(undoFundsId2, new AddFunds("id2", -1000.0)));
+
+        inParallel(addFunds1, addFunds2);
+
+        Result<SagaError, Saga<SpecificRecord>> sagaBuildResult = builder.build();
+        assertThat(sagaBuildResult.isSuccess()).isEqualTo(true);
+
+        return sagaBuildResult.getOrElse(null);
+    }
+
+    @Test
+    void testSuccessfulSaga() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        UUID sagaRequestId = UUID.randomUUID();
+        Saga<SpecificRecord> saga = getBasicSaga();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(sagaRequestId, saga));
+
+        scc.actionRequestVerifier().verifySingle((id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("createAccount");
+            assertThat(actionRequest.actionId()).isEqualTo(action1);
+            assertThat(actionRequest.actionCommand().commandId()).isEqualTo(createAccountId1);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(2, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SetInitialState.class);
+                Saga s = ((SagaStateTransition.SetInitialState) stateTransition).sagaState();
+                assertThat(s.status()).isEqualTo(SagaStatus.NotStarted);
+                assertThat(s.sequence().getSeq()).isEqualTo(0);
+                assertThat(s.actions()).containsKeys(action1, action2);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.TransitionList.class);
+                SagaStateTransition.TransitionList transitionList = ((SagaStateTransition.TransitionList) stateTransition);
+                assertThat(transitionList.actions().size()).isEqualTo(1);
+                assertThat(transitionList.actions().get(0).actionStatus()).isEqualTo(ActionStatus.InProgress);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(0);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Pending);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Pending);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(1);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.InProgress);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Pending);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        // create account successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, createAccountId1, Result.success(true)));
+
+        scc.sagaStateTransitionVerifier.verifyMultiple(2, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action1);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Completed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.TransitionList.class);
+                SagaStateTransition.TransitionList transitionList = ((SagaStateTransition.TransitionList) stateTransition);
+                assertThat(transitionList.actions().size()).isEqualTo(1);
+                assertThat(transitionList.actions().get(0).actionStatus()).isEqualTo(ActionStatus.InProgress);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(2);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Pending);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(3);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.InProgress);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionRequestVerifier().verifySingle((id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("addFunds");
+            assertThat(actionRequest.actionId()).isEqualTo(action2);
+            assertThat(actionRequest.actionCommand().commandId()).isEqualTo(addFundsId1);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        // add funds successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action2, addFundsId1, Result.success(true)));
+
+        scc.sagaStateTransitionVerifier.verifyMultiple(2, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action2);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Completed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaId()).isEqualTo(saga.sagaId());
+                assertThat(c.sagaStatus).isEqualTo(SagaStatus.Completed);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(4);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Completed);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(5);
+                assertThat(state.status()).isEqualTo(SagaStatus.Completed);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Completed);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result.isSuccess()).isTrue();
+        });
+    }
+
+    @Test
+    void testShortCircuitOnFailure() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        UUID sagaRequestId = UUID.randomUUID();
+        Saga<SpecificRecord> saga = getBasicSaga();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(sagaRequestId, saga));
+
+        // already verified in above test
+        scc.actionRequestVerifier().drainAll();
+        scc.sagaStateTransitionVerifier().drainAll();
+        scc.sagaStateVerifier().drainAll();
+
+        // create account failed
+        SagaError sagaError = SagaError.of(SagaError.Reason.CommandError, "Oh noes");
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, createAccountId1, Result.failure(sagaError)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(2, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action1);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaStatus()).isEqualTo(SagaStatus.Failed);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(2);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Failed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Pending);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(3);
+                assertThat(state.status()).isEqualTo(SagaStatus.Failed);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Failed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Pending);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result().isSuccess()).isFalse();
+            assertThat(response.result().failureReasons()).contains(NonEmptyList.of(sagaError));
+        });
+    }
+
+    @Test
+    void testBypassUndoOnFailureIfNotDefined() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        UUID sagaRequestId = UUID.randomUUID();
+        Saga<SpecificRecord> saga = getBasicSaga();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(sagaRequestId, saga));
+
+        // create account successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, createAccountId1, Result.success(true)));
+
+        scc.actionRequestVerifier().drainAll();
+        scc.sagaStateTransitionVerifier().drainAll();
+        scc.sagaStateVerifier().drainAll();
+
+        // add funds failed
+        SagaError sagaError = SagaError.of(SagaError.Reason.CommandError, "Oh noes");
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action2, addFundsId1, Result.failure(sagaError)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(4, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action2);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaStatus()).isEqualTo(SagaStatus.InFailure);
+            } else if (i == 2) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.TransitionList.class);
+                SagaStateTransition.TransitionList transitionList = ((SagaStateTransition.TransitionList) stateTransition);
+                assertThat(transitionList.actions().size()).isEqualTo(1);
+                assertThat(transitionList.actions().get(0).actionStatus()).isEqualTo(ActionStatus.UndoBypassed);
+            } else if (i == 3) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaStatus()).isEqualTo(SagaStatus.Failed);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(4, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(4);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(5);
+                assertThat(state.status()).isEqualTo(SagaStatus.InFailure);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 2) {
+                assertThat(state.sequence().getSeq()).isEqualTo(6);
+                assertThat(state.status()).isEqualTo(SagaStatus.InFailure);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.UndoBypassed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 3) {
+                assertThat(state.sequence().getSeq()).isEqualTo(7);
+                assertThat(state.status()).isEqualTo(SagaStatus.Failed);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.UndoBypassed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result().isSuccess()).isFalse();
+            assertThat(response.result().failureReasons()).contains(NonEmptyList.of(sagaError));
+        });
+    }
+
+    @Test
+    void testUndoCommandOnFailure() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        UUID sagaRequestId = UUID.randomUUID();
+        Saga<SpecificRecord> saga = getSagaWithUndo();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(sagaRequestId, saga));
+
+        // add funds successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, addFundsId1, Result.success(true)));
+
+        scc.actionRequestVerifier().drainAll();
+        scc.sagaStateTransitionVerifier().drainAll();
+        scc.sagaStateVerifier().drainAll();
+
+        // transfer funds failed
+        SagaError sagaError = SagaError.of(SagaError.Reason.CommandError, "Oh noes");
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action2, transferId, Result.failure(sagaError)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(3, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action2);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaStatus()).isEqualTo(SagaStatus.InFailure);
+            } else if (i == 2) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.TransitionList.class);
+                SagaStateTransition.TransitionList transitionList = ((SagaStateTransition.TransitionList) stateTransition);
+                assertThat(transitionList.actions().size()).isEqualTo(1);
+                assertThat(transitionList.actions().get(0).actionStatus()).isEqualTo(ActionStatus.InUndo);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(3, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(4);
+                assertThat(state.status()).isEqualTo(SagaStatus.InProgress);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(5);
+                assertThat(state.status()).isEqualTo(SagaStatus.InFailure);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Completed);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 2) {
+                assertThat(state.sequence().getSeq()).isEqualTo(6);
+                assertThat(state.status()).isEqualTo(SagaStatus.InFailure);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.InUndo);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionRequestVerifier().verifySingle((id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("addFunds");
+            assertThat(actionRequest.actionId()).isEqualTo(action1);
+            assertThat(actionRequest.actionCommand().commandId()).isEqualTo(undoFundsId1);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        // undo add funds successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, undoFundsId1, Result.success(true)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(2, (i, id, stateTransition) -> {
+            if (i == 0) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaActionStatusChanged.class);
+                SagaStateTransition.SagaActionStatusChanged c = ((SagaStateTransition.SagaActionStatusChanged) stateTransition);
+                assertThat(c.actionId()).isEqualTo(action1);
+                assertThat(c.actionStatus()).isEqualTo(ActionStatus.Completed);
+            } else if (i == 1) {
+                assertThat(stateTransition).isInstanceOf(SagaStateTransition.SagaStatusChanged.class);
+                SagaStateTransition.SagaStatusChanged c = ((SagaStateTransition.SagaStatusChanged) stateTransition);
+                assertThat(c.sagaStatus()).isEqualTo(SagaStatus.Failed);
+            }
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+            if (i == 0) {
+                assertThat(state.sequence().getSeq()).isEqualTo(7);
+                assertThat(state.status()).isEqualTo(SagaStatus.InFailure);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Undone);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            } else if (i == 1) {
+                assertThat(state.sequence().getSeq()).isEqualTo(8);
+                assertThat(state.status()).isEqualTo(SagaStatus.Failed);
+                assertThat(state.actions().get(action1).status()).isEqualTo(ActionStatus.Undone);
+                assertThat(state.actions().get(action2).status()).isEqualTo(ActionStatus.Failed);
+            }
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result().isSuccess()).isFalse();
+            assertThat(response.result().failureReasons()).contains(NonEmptyList.of(sagaError));
+        });
+    }
+
+    @Test
+    void testParallelSuccessful() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        Saga<SpecificRecord> saga = getParallelSaga();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(UUID.randomUUID(), saga));
+
+        scc.actionRequestVerifier().verifyMultiple(2, (i, id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("addFunds");
+            assertThat(actionRequest.actionId()).isIn(action1, action2);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(2, (i, id, stateTransition) -> {
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, createAccountId1, Result.success(true)));
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action2, createAccountId2, Result.success(true)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(3, (i, id, stateTransition) -> {
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(3, (i, id, state) -> {
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result().isSuccess()).isTrue();
+        });
+    }
+
+    @Test
+    void testFailureInParallel() {
+        SagaCoordinatorContext scc = new SagaCoordinatorContext();
+
+        Saga<SpecificRecord> saga = getParallelSaga();
+        scc.sagaRequestPublisher().publish(saga.sagaId(), new SagaRequest<>(UUID.randomUUID(), saga));
+
+        scc.actionRequestVerifier().verifyMultiple(2, (i, id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("addFunds");
+            assertThat(actionRequest.actionId()).isIn(action1, action2);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(2, (i, id, stateTransition) -> {
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(2, (i, id, state) -> {
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, addFundsId1, Result.success(true)));
+        SagaError sagaError = SagaError.of(SagaError.Reason.CommandError, "Oh noes");
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action2, addFundsId2, Result.failure(sagaError)));
+
+        scc.sagaStateTransitionVerifier().verifyMultiple(4, (i, id, stateTransition) -> {
+        });
+        scc.sagaStateTransitionVerifier().verifyNoRecords();
+
+        scc.sagaStateVerifier().verifyMultiple(4, (i, id, state) -> {
+        });
+        scc.sagaStateVerifier().verifyNoRecords();
+
+        // undo non-failing action
+        scc.actionRequestVerifier().verifySingle((id, actionRequest) -> {
+            assertThat(id).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(actionRequest.actionType()).isEqualTo("addFunds");
+            assertThat(actionRequest.actionId()).isEqualTo(action1);
+            assertThat(actionRequest.actionCommand().commandId()).isEqualTo(undoFundsId1);
+        });
+        scc.actionRequestVerifier().verifyNoRecords();
+
+        // undo successful
+        scc.actionResponsePublisher().publish(saga.sagaId(), new ActionResponse(saga.sagaId(), action1, undoFundsId1, Result.success(true)));
+
+        scc.sagaResponseVerifier().verifySingle((id, response) -> {
+            assertThat(response.sagaId()).isEqualTo(saga.sagaId());
+            assertThat(response.result().isSuccess()).isFalse();
+            assertThat(response.result().failureReasons()).contains(NonEmptyList.of(sagaError));
+        });
+    }
+}

--- a/java/simplesaga-serialization/pom.xml
+++ b/java/simplesaga-serialization/pom.xml
@@ -26,12 +26,13 @@
 
         <dependency>
             <groupId>io.simplesource</groupId>
-            <artifactId>simplesaga-saga</artifactId>
+            <artifactId>simplesaga-testutils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.simplesource</groupId>
-            <artifactId>simplesaga-testutils</artifactId>
+            <artifactId>simplesaga-dsl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/java/simplesaga-serialization/src/main/java/io/simplesource/saga/serialization/avro/AvroSagaSerdes.java
+++ b/java/simplesaga-serialization/src/main/java/io/simplesource/saga/serialization/avro/AvroSagaSerdes.java
@@ -9,7 +9,6 @@ import io.simplesource.saga.model.saga.SagaStatus;
 import io.simplesource.saga.model.serdes.SagaSerdes;
 import io.simplesource.saga.serialization.avro.generated.*;
 import io.simplesource.saga.serialization.utils.SerdeUtils;
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serde;
 
 import java.util.List;

--- a/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/SagaTestUtils.java
+++ b/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/SagaTestUtils.java
@@ -5,7 +5,7 @@ import io.simplesource.saga.model.action.ActionCommand;
 import io.simplesource.saga.model.action.SagaAction;
 import io.simplesource.saga.model.saga.Saga;
 import io.simplesource.saga.model.saga.SagaError;
-import io.simplesource.saga.saga.dsl.SagaDsl;
+import io.simplesource.saga.dsl.SagaDsl;
 import io.simplesource.saga.serialization.avro.generated.test.AddFunds;
 import io.simplesource.saga.serialization.avro.generated.test.CreateAccount;
 import io.simplesource.saga.serialization.avro.generated.test.TransferFunds;
@@ -16,7 +16,7 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static io.simplesource.saga.saga.dsl.SagaDsl.inParallel;
+import static io.simplesource.saga.dsl.SagaDsl.inParallel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SagaTestUtils {

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -25,6 +25,7 @@ lazy val baseDeps = Seq(
     "io.simplesource"  % "simplesaga-model"                   % simpleSagaV,
     "io.simplesource"  % "simplesaga-action"                  % simpleSagaV,
     "io.simplesource"  % "simplesaga-http"                    % simpleSagaV,
+    "io.simplesource"  % "simplesaga-dsl"                     % simpleSagaV,
     "io.simplesource"  % "simplesaga-saga"                    % simpleSagaV,
   )
 )

--- a/scala/modules/scala/src/main/scala/io/simplesource/saga/scala/dsl/SagaScalaDsl.scala
+++ b/scala/modules/scala/src/main/scala/io/simplesource/saga/scala/dsl/SagaScalaDsl.scala
@@ -1,7 +1,7 @@
 package io.simplesource.saga.scala.dsl
 
-import io.simplesource.saga.saga.dsl.SagaDsl
-import io.simplesource.saga.saga.dsl.SagaDsl.SubSaga
+import io.simplesource.saga.dsl.SagaDsl
+import io.simplesource.saga.dsl.SagaDsl.SubSaga
 
 import scala.collection.JavaConverters._
 

--- a/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/dsl/ScalaDslTest.scala
+++ b/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/dsl/ScalaDslTest.scala
@@ -3,7 +3,7 @@ import java.util.UUID
 
 import io.simplesource.saga.model.action.ActionCommand
 import io.simplesource.saga.model.saga.Saga
-import io.simplesource.saga.saga.dsl.SagaDsl.SagaBuilder
+import io.simplesource.saga.dsl.SagaDsl.SagaBuilder
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._

--- a/scala/modules/user/src/main/scala/io/simplesource/saga/user/client/App.scala
+++ b/scala/modules/user/src/main/scala/io/simplesource/saga/user/client/App.scala
@@ -25,7 +25,7 @@ import io.simplesource.saga.user.shared.TopicUtils
 import io.simplesource.saga.scala.serdes.JsonSerdes
 
 import scala.collection.JavaConverters._
-import io.simplesource.saga.saga.dsl.SagaDsl._
+import io.simplesource.saga.dsl.SagaDsl._
 import io.simplesource.saga.user.action.HttpClient
 
 object App {


### PR DESCRIPTION
The DSL was put into a new module to untangle this circular dependency:
1. We need to add the `simplesaga-serialization` dependency to `simplesaga-saga` tests for the Serdes needed to interact with Kafka Streams.
2. But `simplesaga-serialization` tests have an existing dependency on `simplesaga-saga` (for the DSL).

The alternatives would be putting the integration tests in a new module, or putting the coordinator in a new module...