### PR TITLE
Remember the last sequence number per (Saga, Aggregate) for simple sourcing actions

### DIFF
--- a/java/simplesaga-action/src/main/java/io/simplesource/saga/action/sourcing/CommandSpec.java
+++ b/java/simplesaga-action/src/main/java/io/simplesource/saga/action/sourcing/CommandSpec.java
@@ -1,6 +1,7 @@
 package io.simplesource.saga.action.sourcing;
 
 import io.simplesource.data.Result;
+import io.simplesource.data.Sequence;
 import io.simplesource.kafka.api.CommandSerdes;
 import lombok.Value;
 
@@ -18,8 +19,7 @@ public final class CommandSpec<A, I, K, C> {
     public final Function<A, Result<Throwable, I>> decode;
     public final Function<I, C> commandMapper;
     public final Function<I, K> keyMapper;
+    public final Function<I, Sequence> sequenceMapper;
     public final CommandSerdes<K, C> commandSerdes;
-    public final String aggregateName;
     public final long timeOutMillis;
-
 }

--- a/java/simplesaga-action/src/test/avro/TestSchemas.avdl
+++ b/java/simplesaga-action/src/test/avro/TestSchemas.avdl
@@ -22,6 +22,7 @@ protocol Schemas {
 
   record AccountCommand {
     AccountId id;
+    long sequence;
     union {
       CreateAccount,
       AddFunds,

--- a/java/simplesaga-serialization/src/main/avro/ActionSchemas.avdl
+++ b/java/simplesaga-serialization/src/main/avro/ActionSchemas.avdl
@@ -89,4 +89,9 @@ protocol SagaSchemas {
       AvroSagaTransitionList
     } transition;
   }
+
+  record AvroTuple2 {
+    bytes v1;
+    bytes v2;
+  }
 }

--- a/java/simplesaga-shared/pom.xml
+++ b/java/simplesaga-shared/pom.xml
@@ -59,4 +59,29 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>idl-protocol</goal>
+                        </goals>
+
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+                            <testSourceDirectory>${project.basedir}/src/test/avro</testSourceDirectory>
+                            <stringType>String</stringType>
+                            <enableDecimalLogicalType>true</enableDecimalLogicalType>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/java/simplesaga-shared/src/main/avro/ActionSchemas.avdl
+++ b/java/simplesaga-shared/src/main/avro/ActionSchemas.avdl
@@ -1,0 +1,7 @@
+@namespace("io.simplesource.saga.shared.avro.generated")
+protocol SagaSchemas {
+  record AvroTuple2 {
+    bytes v1;
+    bytes v2;
+  }
+}

--- a/java/simplesaga-shared/src/main/java/io/simplesource/saga/shared/serialization/TupleSerdes.java
+++ b/java/simplesaga-shared/src/main/java/io/simplesource/saga/shared/serialization/TupleSerdes.java
@@ -1,0 +1,117 @@
+package io.simplesource.saga.shared.serialization;
+
+import io.simplesource.kafka.internal.util.Tuple2;
+import io.simplesource.saga.shared.avro.generated.AvroTuple2;
+import org.apache.avro.io.*;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class TupleSerdes {
+    private static DatumWriter<AvroTuple2> datumWriter = new SpecificDatumWriter<>(AvroTuple2.SCHEMA$);
+    private static DatumReader<AvroTuple2> datumReader = new SpecificDatumReader<>(AvroTuple2.SCHEMA$);
+
+    private static <A, B> Serializer<Tuple2<A, B>> tuple2Serializer(final Serializer<A> serA, final Serializer<B> serB) {
+        return new Serializer<Tuple2<A, B>>() {
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) {
+                serA.configure(configs, isKey);
+                serB.configure(configs, isKey);
+            }
+
+            @Override
+            public byte[] serialize(String topic, Tuple2<A, B> data) {
+                byte[] bytesA = serA.serialize(topic + ".1", data.v1());
+                byte[] bytesB = serB.serialize(topic + ".2", data.v2());
+
+                AvroTuple2 tuple2 = new AvroTuple2(ByteBuffer.wrap(bytesA), ByteBuffer.wrap(bytesB));
+
+
+                ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(stream, null);
+
+                try {
+                    datumWriter.write(tuple2, encoder);
+                    encoder.flush();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                return stream.toByteArray();
+            }
+
+            @Override
+            public void close() {
+                serA.close();
+                serB.close();
+            }
+        };
+    }
+
+    private static <A, B> Deserializer<Tuple2<A, B>> tuple2Deserializer(final Deserializer<A> deA, final Deserializer<B> deB) {
+        return new Deserializer<Tuple2<A, B>>() {
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) {
+                deA.configure(configs, isKey);
+                deB.configure(configs, isKey);
+            }
+
+            @Override
+            public Tuple2<A, B> deserialize(String topic, byte[] data) {
+                BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+                try {
+                    AvroTuple2 record = datumReader.read(null, decoder);
+                    byte[] bytesA = record.getV1().array();
+                    byte[] bytesB = record.getV2().array();
+                    A a = deA.deserialize(topic + "_1", bytesA);
+                    B b = deB.deserialize(topic + "_2", bytesB);
+                    return new Tuple2<>(a, b);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void close() {
+                deA.close();
+                deB.close();
+            }
+        };
+    }
+
+    public static <A, B> Serde<Tuple2<A, B>> tuple2(final Serde<A> serdeA, final Serde<B> serdeB) {
+        return new Serde<Tuple2<A, B>>() {
+
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) {
+                serdeA.configure(configs, isKey);
+                serdeB.configure(configs, isKey);
+            }
+
+            @Override
+            public void close() {
+                serdeA.close();
+                serdeB.close();
+
+            }
+
+            @Override
+            public Serializer<Tuple2<A, B>> serializer() {
+                return tuple2Serializer(serdeA.serializer(), serdeB.serializer());
+            }
+
+            @Override
+            public Deserializer<Tuple2<A, B>> deserializer() {
+                return tuple2Deserializer(serdeA.deserializer(), serdeB.deserializer());
+            }
+        };
+    }
+}

--- a/java/simplesaga-shared/src/test/avro/TestSchemas.avdl
+++ b/java/simplesaga-shared/src/test/avro/TestSchemas.avdl
@@ -1,0 +1,8 @@
+@namespace("io.simplesource.saga.shared.avro.generated.test")
+protocol Schemas {
+  record User {
+    string firstName;
+    string lastName;
+    int yearOfBirth;
+  }
+}

--- a/java/simplesaga-shared/src/test/java/io/simplesource/saga/shared/avro/ActionSerdesTest.java
+++ b/java/simplesaga-shared/src/test/java/io/simplesource/saga/shared/avro/ActionSerdesTest.java
@@ -1,0 +1,34 @@
+package io.simplesource.saga.shared.avro;
+
+import io.simplesource.kafka.internal.util.Tuple2;
+import io.simplesource.saga.shared.serialization.TupleSerdes;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.Test;
+
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class ActionSerdesTest {
+    private static String FAKE_TOPIC = "topic";
+    @Test
+    void tuple2Test() {
+        Serde<Tuple2<Long, String>> tupleSerde = TupleSerdes.tuple2(Serdes.Long(), Serdes.String());
+
+        byte[] serialized = tupleSerde.serializer().serialize(FAKE_TOPIC, Tuple2.of(42L, "Hello"));
+        Tuple2<Long, String> deserialized = tupleSerde.deserializer().deserialize(FAKE_TOPIC, serialized);
+        assertThat(deserialized.v1()).isEqualTo(42L);
+        assertThat(deserialized.v2()).isEqualTo("Hello");
+
+        // now do nested test for good measure
+        Serde<Tuple2<Long, Tuple2<Long, String>>> nestedTupleSerde = TupleSerdes.tuple2(Serdes.Long(), tupleSerde);
+
+        byte[] serializedNested = nestedTupleSerde.serializer().serialize(FAKE_TOPIC, Tuple2.of(42L, Tuple2.of(42L, "Hello")));
+        Tuple2<Long, Tuple2<Long, String>> deserializedNested = nestedTupleSerde.deserializer().deserialize(FAKE_TOPIC, serializedNested);
+        assertThat(deserializedNested.v2().v1()).isEqualTo(42L);
+        assertThat(deserializedNested.v2().v2()).isEqualTo("Hello");
+        assertThat(deserializedNested.v1()).isEqualTo(42L);
+    }
+}

--- a/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/App.scala
+++ b/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/App.scala
@@ -32,7 +32,7 @@ object App {
           .withResourceNamingStrategy(new PrefixResourceNamingStrategy(constants.commandTopicPrefix))
           .withName(constants.userAggregateName)
           .withInitialValue(_ => None)
-          .withInvalidSequenceStrategy(InvalidSequenceStrategy.Strict)
+          .withInvalidSequenceStrategy(InvalidSequenceStrategy.LastWriteWins) // TODO: re-enable sequence checking
           .withDefaultTopicSpec(constants.partitions, constants.replication, constants.retentionDays)
           .build())
       .addAggregate(
@@ -45,7 +45,7 @@ object App {
           .withResourceNamingStrategy(new PrefixResourceNamingStrategy(constants.commandTopicPrefix))
           .withName(constants.accountAggregateName)
           .withInitialValue(_ => None)
-          .withInvalidSequenceStrategy(InvalidSequenceStrategy.Strict)
+          .withInvalidSequenceStrategy(InvalidSequenceStrategy.LastWriteWins) // TODO: re-enable sequence checking
           .withDefaultTopicSpec(constants.partitions, constants.replication, constants.retentionDays)
           .build())
       .start()

--- a/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/model/auction.scala
+++ b/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/model/auction.scala
@@ -5,9 +5,9 @@ object auction {
   final case class Reservation(reservationId: UUID, description: String, amount: BigDecimal)
   final case class Account(name: String, funds: BigDecimal, reservations: List[Reservation] = List.empty)
 
-  sealed trait AccountCommand {
-    def accountId: UUID
-  }
+  final case class AccountCommandInfo(accountId: UUID, sequence: Long, command: AccountCommand)
+
+  sealed trait AccountCommand
 
   object AccountCommand {
     final case class CreateAccount(accountId: UUID, userName: String, funds: BigDecimal)

--- a/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/model/user.scala
+++ b/scala/modules/user/src/main/scala/io/simplesource/saga/user/command/model/user.scala
@@ -4,6 +4,8 @@ import java.util.UUID
 object user {
   final case class User(firstName: String, lastName: String, yearOfBirth: Int)
 
+  final case class UserCommandInfo(userId: UUID, sequence: Long, command: UserCommand)
+
   sealed trait UserCommand {
     def userId: UUID
   }


### PR DESCRIPTION
Added a Tuple Serde implementation.
Added code in the SourcingStream to create a table of latest updates per (Saga, Aggregate)
Joined an incoming action request to derive the next sequence ID

Issue: #22