### PR TITLE
took the CommandId out of the Saga Api

### DIFF
--- a/java/simplesaga-action/src/main/java/io/simplesource/saga/action/internal/AsyncActionProcessor.java
+++ b/java/simplesaga-action/src/main/java/io/simplesource/saga/action/internal/AsyncActionProcessor.java
@@ -95,15 +95,6 @@ final class AsyncActionProcessor {
         }
     }
 
-    // execute lazy code and wraps exceptions in a result
-    private static <X> Result<Throwable, X> tryPure(Supplier<X> xSupplier) {
-        try {
-            return Result.success(xSupplier.get());
-        } catch (Throwable e) {
-            return Result.failure(e);
-        }
-    }
-
     // evaluates code returning a Result that may throw an exception,
     // and turns it into a Result that is guaranteed not to throw
     // (i.e. absorbs exceptions into the failure mode)

--- a/java/simplesaga-action/src/test/java/io/simplesource/saga/action/async/AsyncStreamTests.java
+++ b/java/simplesaga-action/src/test/java/io/simplesource/saga/action/async/AsyncStreamTests.java
@@ -146,7 +146,7 @@ class AsyncStreamTests {
     }
 
     private static ActionRequest<SpecificRecord> createRequest(AsyncTestCommand AsyncTestCommand, CommandId commandId) {
-        ActionCommand<SpecificRecord> actionCommand = new ActionCommand<>(commandId, AsyncTestCommand);
+        ActionCommand<SpecificRecord> actionCommand = ActionCommand.of(commandId, AsyncTestCommand);
         return ActionRequest.<SpecificRecord>builder()
                 .sagaId(SagaId.random())
                 .actionId(ActionId.random())

--- a/java/simplesaga-action/src/test/java/io/simplesource/saga/action/sourcing/SourcingStreamTests.java
+++ b/java/simplesaga-action/src/test/java/io/simplesource/saga/action/sourcing/SourcingStreamTests.java
@@ -102,7 +102,7 @@ class SourcingStreamTests {
     }
 
     private static ActionRequest<SpecificRecord> createRequest(SagaId sagaId, AccountCommand accountCommand, CommandId commandId) {
-        ActionCommand<SpecificRecord> actionCommand = new ActionCommand<>(commandId, accountCommand);
+        ActionCommand<SpecificRecord> actionCommand = ActionCommand.of(commandId, accountCommand);
         return ActionRequest.<SpecificRecord>builder()
                 .sagaId(sagaId)
                 .actionId(ActionId.random())

--- a/java/simplesaga-client/src/main/java/io/simplesource/saga/client/dsl/SagaDsl.java
+++ b/java/simplesaga-client/src/main/java/io/simplesource/saga/client/dsl/SagaDsl.java
@@ -1,5 +1,6 @@
 package io.simplesource.saga.client.dsl;
 
+import io.simplesource.api.CommandId;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
@@ -106,15 +107,15 @@ public final class SagaDsl {
 
         public SubSaga<A> addAction(ActionId actionId,
                                     String actionType,
-                                    ActionCommand<A> actionCommand) {
-            return addAction(actionId, actionType, actionCommand, Optional.empty());
+                                    A actionCommand) {
+            return addAction(actionId, actionType, ActionCommand.of(CommandId.random(), actionCommand), Optional.empty());
         }
 
         public SubSaga<A> addAction(ActionId actionId,
                                     String actionType,
-                                    ActionCommand<A> actionCommand,
-                                    ActionCommand<A> undoActionCommand) {
-            return addAction(actionId, actionType, actionCommand, Optional.of(undoActionCommand));
+                                    A actionCommand,
+                                    A undoActionCommand) {
+            return addAction(actionId, actionType, ActionCommand.of(CommandId.random(), actionCommand), Optional.of(ActionCommand.of(CommandId.random(), undoActionCommand)));
         }
 
         public Result<SagaError, Saga<A>> build() {

--- a/java/simplesaga-client/src/test/java/io/simplesource/saga/client/dsl/DslTest.java
+++ b/java/simplesaga-client/src/test/java/io/simplesource/saga/client/dsl/DslTest.java
@@ -10,7 +10,6 @@ import io.simplesource.data.NonEmptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static io.simplesource.saga.client.dsl.SagaDsl.*;
 
-import io.simplesource.saga.model.action.ActionCommand;
 import io.simplesource.saga.model.action.ActionId;
 import io.simplesource.saga.model.saga.Saga;
 import io.simplesource.saga.shared.utils.Sets;
@@ -20,7 +19,7 @@ class DslTest {
     SagaBuilder<String> builder = SagaBuilder.create();
 
     SubSaga<String> create(String a) {
-        return builder.addAction(ActionId.random(), "actionType-" + a, new ActionCommand<>(CommandId.random(), "Command-" + a));
+        return builder.addAction(ActionId.random(), "actionType-" + a, "Command-" + a);
     }
 
     void dependsOnSet(String action, Set<String> dependsOn, Saga<String> saga) {

--- a/java/simplesaga-model/src/main/java/io/simplesource/saga/model/action/ActionCommand.java
+++ b/java/simplesaga-model/src/main/java/io/simplesource/saga/model/action/ActionCommand.java
@@ -3,7 +3,7 @@ package io.simplesource.saga.model.action;
 import io.simplesource.api.CommandId;
 import lombok.Value;
 
-@Value
+@Value(staticConstructor = "of")
 public class ActionCommand<A> {
     public final CommandId commandId;
     public final A command;

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/SagaApp.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/SagaApp.java
@@ -3,7 +3,7 @@ package io.simplesource.saga.saga;
 import io.simplesource.saga.model.specs.ActionProcessorSpec;
 import io.simplesource.saga.model.specs.SagaSpec;
 import io.simplesource.saga.saga.app.SagaContext;
-import io.simplesource.saga.saga.app.SagaCoordinatorTopologyBuilder;
+import io.simplesource.saga.saga.app.SagaTopologyBuilder;
 import io.simplesource.saga.saga.app.SagaStream;
 import io.simplesource.saga.shared.topics.TopicConfig;
 import io.simplesource.saga.shared.topics.TopicConfigBuilder;
@@ -43,7 +43,7 @@ final public class SagaApp<A> {
     private static Logger logger = LoggerFactory.getLogger(SagaApp.class);
     private final SagaSpec<A> sagaSpec;
     private final TopicConfig sagaTopicConfig;
-    private final SagaCoordinatorTopologyBuilder<A> topologyBuilder;
+    private final SagaTopologyBuilder<A> topologyBuilder;
     private final List<TopicCreation> topics;
 
     public SagaApp(SagaSpec<A> sagaSpec, TopicConfigBuilder.BuildSteps topicBuildFn) {
@@ -56,7 +56,7 @@ final public class SagaApp<A> {
                         org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_COMPACT
                 )),
                 topicBuildFn);
-        topologyBuilder = new SagaCoordinatorTopologyBuilder<>(sagaSpec, sagaTopicConfig);
+        topologyBuilder = new SagaTopologyBuilder<>(sagaSpec, sagaTopicConfig);
         topics = TopicCreation.allTopics(sagaTopicConfig);
     }
 

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaStream.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaStream.java
@@ -25,7 +25,7 @@ final public class SagaStream {
         return (k, v) -> logger.info("{}: {}={}", prefix, k.toString().substring(0, 6), v.toString());
     }
 
-    public static <A> void addSubTopology(SagaCoordinatorTopologyBuilder.SagaTopologyContext<A> topologyContext,
+    public static <A> void addSubTopology(SagaTopologyBuilder.SagaTopologyContext<A> topologyContext,
                                           SagaContext<A> sagaContext) {
         KStream<SagaId, ActionResponse> actionResponse = SagaConsumer.actionResponse(
                 sagaContext.aSpec,

--- a/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaTopologyBuilder.java
+++ b/java/simplesaga-saga/src/main/java/io/simplesource/saga/saga/app/SagaTopologyBuilder.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class SagaCoordinatorTopologyBuilder<A> {
+public class SagaTopologyBuilder<A> {
 
     private final SagaSpec<A> sagaSpec;
     private final TopicConfig sagaTopicConfig;
@@ -32,7 +32,7 @@ public class SagaCoordinatorTopologyBuilder<A> {
         public final KStream<SagaId, SagaStateTransition> sagaStateTransition;
     }
 
-    public SagaCoordinatorTopologyBuilder(SagaSpec<A> sagaSpec, TopicConfig sagaTopicConfig) {
+    public SagaTopologyBuilder(SagaSpec<A> sagaSpec, TopicConfig sagaTopicConfig) {
         this.sagaSpec = sagaSpec;
         this.sagaTopicConfig = sagaTopicConfig;
     }

--- a/java/simplesaga-saga/src/test/java/io/simplesource/saga/saga/app/SagaUtilsTest.java
+++ b/java/simplesaga-saga/src/test/java/io/simplesource/saga/saga/app/SagaUtilsTest.java
@@ -81,17 +81,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga).stream().map(a -> a.actionId)).containsExactlyInAnyOrder(action1, action3);
@@ -108,18 +108,18 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .dependency(action3)
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga).stream().map(a -> a.actionId)).containsOnly(action3);
@@ -134,7 +134,7 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga)).isEmpty();
@@ -151,17 +151,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Failed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga).stream().map(a -> a.actionId)).containsExactlyInAnyOrder(action1, action3);
@@ -182,20 +182,20 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id1", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand1, new AddFunds("id1", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id1", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand1, new AddFunds("id1", -10.0)))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Failed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id2", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand2, new AddFunds("id2", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id2", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand2, new AddFunds("id2", -10.0)))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id3", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand3, new AddFunds("id3", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id3", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand3, new AddFunds("id3", -10.0)))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga).stream().map(a -> a.actionId)).containsExactlyInAnyOrder(action1, action3);
@@ -217,21 +217,21 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id1", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand1, new AddFunds("id1", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id1", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand1, new AddFunds("id1", -10.0)))
                         .dependency(action3)
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Failed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id2", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand2, new AddFunds("id2", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id2", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand2, new AddFunds("id2", -10.0)))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id3", 10.0)))
-                        .undoCommand(new ActionCommand<>(undoCommand3, new AddFunds("id3", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id3", 10.0)))
+                        .undoCommand(ActionCommand.of(undoCommand3, new AddFunds("id3", -10.0)))
                         .build())
                 .build();
         assertThat(SagaUtils.getNextActions(saga).stream().map(a -> a.actionId)).containsOnly(action1);
@@ -250,17 +250,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         SagaStateTransition transition = new SagaStateTransition.SetInitialState<>(saga);
@@ -281,17 +281,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         SagaStateTransition transition = new SagaStateTransition.SagaActionStatusChanged(sagaId, action1, ActionStatus.Completed, Collections.emptyList());
@@ -312,21 +312,21 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.InUndo)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id1", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id1", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id1", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id1", -10.0)))
                         .dependency(action3)
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Failed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id2", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id2", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id2", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id2", -10.0)))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.InUndo)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id3", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id3", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id3", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id3", -10.0)))
                         .build())
                 .build();
         SagaStateTransition transition = new SagaStateTransition.SagaActionStatusChanged(sagaId, action1, ActionStatus.Completed, Collections.emptyList());
@@ -347,21 +347,21 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.InUndo)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id1", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id1", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id1", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id1", -10.0)))
                         .dependency(action3)
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Failed)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id2", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id2", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id2", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id2", -10.0)))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.InUndo)
-                        .command(new ActionCommand<>(CommandId.random(), new AddFunds("id3", 10.0)))
-                        .undoCommand(new ActionCommand<>(CommandId.random(), new AddFunds("id3", -10.0)))
+                        .command(ActionCommand.of(CommandId.random(), new AddFunds("id3", 10.0)))
+                        .undoCommand(ActionCommand.of(CommandId.random(), new AddFunds("id3", -10.0)))
                         .build())
                 .build();
         SagaStateTransition transition = new SagaStateTransition.SagaActionStatusChanged(sagaId, action1, ActionStatus.Failed, Collections.emptyList());
@@ -382,17 +382,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Completed)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         SagaStateTransition transition = new SagaStateTransition.SagaStatusChanged(sagaId, SagaStatus.Completed, Collections.emptyList());
@@ -413,17 +413,17 @@ class SagaUtilsTest {
                 .action(builder -> builder
                         .id(action1)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id1", "username1")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id1", "username1")))
                         .build())
                 .action(builder -> builder
                         .id(action2)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id2", "username2")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id2", "username2")))
                         .build())
                 .action(builder -> builder
                         .id(action3)
                         .status(ActionStatus.Pending)
-                        .command(new ActionCommand<>(CommandId.random(), new CreateAccount("id3", "username3")))
+                        .command(ActionCommand.of(CommandId.random(), new CreateAccount("id3", "username3")))
                         .build())
                 .build();
         List<SagaStateTransition.SagaActionStatusChanged> transitions = Stream.of(
@@ -449,7 +449,7 @@ class SagaUtilsTest {
         return new SagaAction<>(
                 ActionId.random(),
                 "testAction",
-                new ActionCommand<>(CommandId.random(), new CreateAccount("id", "username")),
+                ActionCommand.of(CommandId.random(), new CreateAccount("id", "username")),
                 Optional.empty(),
                 Collections.emptySet(),
                 status,

--- a/java/simplesaga-serialization/src/main/java/io/simplesource/saga/serialization/avro/SagaSerdeUtils.java
+++ b/java/simplesaga-serialization/src/main/java/io/simplesource/saga/serialization/avro/SagaSerdeUtils.java
@@ -90,7 +90,7 @@ public class SagaSerdeUtils {
     static <A> ActionCommand<A> actionCommandFromAvro(Serde<A> payloadSerde, String payloadTopic, String actionType, AvroActionCommand ac) {
         if (ac == null) return null;
         A command = payloadSerde.deserializer().deserialize(getSubjectName(payloadTopic, actionType), ac.getCommand().array());
-        return new ActionCommand<>(CommandId.of(UUID.fromString(ac.getCommandId())), command);
+        return ActionCommand.of(CommandId.of(UUID.fromString(ac.getCommandId())), command);
     }
 
     static String getSubjectName(String topic, String actionType) {

--- a/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/ActionSerdesPropsTest.java
+++ b/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/ActionSerdesPropsTest.java
@@ -48,7 +48,7 @@ class ActionSerdesPropsTest {
         Arbitrary<ActionCommand<User>> actionCommand = Combinators.combine(
             commandId,
             user
-        ).as(ActionCommand::new);
+        ).as(ActionCommand::of);
         return Combinators.combine(sagaId, actionId, actionCommand, strings).as(
                 (sId,aId, command, actionType) -> ActionRequest.<User>builder()
             .sagaId(sId)

--- a/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/ActionSerdesTest.java
+++ b/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/ActionSerdesTest.java
@@ -49,7 +49,7 @@ class ActionSerdesTest {
         ActionSerdes<User> serdes = AvroSerdes.actionSerdes(payloadSerde, SCHEMA_URL, true);
         User testUser = new User("Albus", "Dumbledore", 1732);
 
-        ActionCommand<User> actionCommand = new ActionCommand<>(CommandId.random(), testUser);
+        ActionCommand<User> actionCommand = ActionCommand.of(CommandId.random(), testUser);
 
         ActionRequest<User> original = ActionRequest.<User>builder()
                 .sagaId(SagaId.random())
@@ -76,7 +76,7 @@ class ActionSerdesTest {
         ActionSerdes<User> serdes = AvroSerdes.Specific.actionSerdes(SCHEMA_URL, true);
         User testUser = new User("Albus", "Dumbledore", 1732);
 
-        ActionCommand<User> actionCommand = new ActionCommand<>(CommandId.random(), testUser);
+        ActionCommand<User> actionCommand = ActionCommand.of(CommandId.random(), testUser);
 
         ActionRequest<User> original = ActionRequest.<User>builder()
                 .sagaId(SagaId.random())
@@ -129,7 +129,7 @@ class ActionSerdesTest {
         ActionSerdes<User> serdes = AvroSerdes.actionSerdes(payloadSerde, SCHEMA_URL, true);
         User testUser = new User("Albus", "Dumbledore", 1732);
 
-        ActionCommand<User> actionCommand = new ActionCommand<>(CommandId.random(), testUser);
+        ActionCommand<User> actionCommand = ActionCommand.of(CommandId.random(), testUser);
 
         ActionRequest<User> request = ActionRequest.<User>builder()
                 .sagaId(SagaId.random())

--- a/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/SagaTestUtils.java
+++ b/java/simplesaga-serialization/src/test/java/io/simplesource/saga/serialization/avro/SagaTestUtils.java
@@ -29,14 +29,14 @@ public class SagaTestUtils {
                 builder.addAction(
                         ActionId.random(),
                         "actionType",
-                        new ActionCommand<>(CommandId.random(), command));
+                        command);
 
         BiFunction<SpecificRecord, SpecificRecord, SagaDsl.SubSaga<SpecificRecord>> addActionWithUndo = (command, undo) ->
                 builder.addAction(
                         ActionId.random(),
                         "actionType",
-                        new ActionCommand<>(CommandId.random(), command),
-                        new ActionCommand<>(CommandId.random(), undo));
+                        command,
+                        undo);
 
         SagaDsl.SubSaga<SpecificRecord> create1 = addAction.apply(new CreateAccount("id1", "User 1"));
         SagaDsl.SubSaga<SpecificRecord> create2 = addAction.apply(new CreateAccount("id2", "User 2"));

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -8,7 +8,7 @@ version := "0.1.0"
 
 val circeV          = "0.10.0"
 val simpleSourcingV = "0.2.5"
-val simpleSagaV     = "0.2.3-SNAPSHOT"
+val simpleSagaV     = "0.1.1-SNAPSHOT"
 val kafkaVersion    = "2.0.0"
 val catsV           = "1.4.0"
 

--- a/scala/modules/scala/src/main/scala/io/simplesource/saga/scala/serdes/JsonSerdes.scala
+++ b/scala/modules/scala/src/main/scala/io/simplesource/saga/scala/serdes/JsonSerdes.scala
@@ -86,7 +86,7 @@ object JsonSerdes {
           .builder[A]()
           .sagaId(SagaId.of(sId))
           .actionId(ActionId.of(aId))
-          .actionCommand(new ActionCommand[A](CommandId.of(cId), c))
+          .actionCommand(ActionCommand.of[A](CommandId.of(cId), c))
           .actionType(at)
           .build()
     ).asSerde
@@ -131,7 +131,7 @@ object JsonSerdes {
     implicit val (acEnc, acDec) =
       productCodecs2[UUID, A, ActionCommand[A]]("commandId", "command")(
         x => (x.commandId.id, x.command),
-        (cid, c) => new ActionCommand[A](CommandId.of(cid), c))
+        (cid, c) => ActionCommand.of[A](CommandId.of(cid), c))
 
     Set(1).map(identity)
 

--- a/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/dsl/ScalaDslTest.scala
+++ b/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/dsl/ScalaDslTest.scala
@@ -31,9 +31,7 @@ class ScalaDslTest extends WordSpec with Matchers {
       val builder = SagaBuilder.create[String]
 
       def create(a: String) =
-        builder.addAction(ActionId.random(),
-                          s"actionType-$a",
-                          new ActionCommand(CommandId.random(), s"Command-$a"))
+        builder.addAction(ActionId.random(), s"actionType-$a", s"Command-$a")
 
       val a1 = create("1")
       val a2 = create("2")

--- a/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/serdes/JsonActionTests.scala
+++ b/scala/modules/scala/src/test/scala/io/simplesource/saga/scala/serdes/JsonActionTests.scala
@@ -42,9 +42,8 @@ class JsonActionTests extends WordSpec with Matchers {
           .builder()
           .sagaId(SagaId.random())
           .actionId(ActionId.random())
-          .actionCommand(
-            new ActionCommand(CommandId.random(),
-                              (UserCommand.Insert(UUID.randomUUID(), "", ""): UserCommand).asJson))
+          .actionCommand(ActionCommand
+            .of(CommandId.random(), (UserCommand.Insert(UUID.randomUUID(), "", ""): UserCommand).asJson))
           .actionType("action")
           .build()
 

--- a/scala/modules/user/src/main/scala/io/simplesource/saga/user/client/App.scala
+++ b/scala/modules/user/src/main/scala/io/simplesource/saga/user/client/App.scala
@@ -90,19 +90,13 @@ object App {
     val addUser = builder.addAction(
       ActionId.random(),
       constants.userActionType,
-      new ActionCommand(
-        CommandId.random(),
-        (UserCommand.Insert(userId = UUID.randomUUID(), firstName, lastName): UserCommand).asJson)
-    )
+      (UserCommand.Insert(userId = UUID.randomUUID(), firstName, lastName): UserCommand).asJson)
 
     val createAccount = builder.addAction(
       ActionId.random(),
       constants.accountActionType,
-      new ActionCommand(CommandId.random(),
-                        (AccountCommand
-                          .CreateAccount(accountId = accountId,
-                                         userName = s"$firstName $lastName",
-                                         funds = 1000): AccountCommand).asJson)
+      (AccountCommand
+        .CreateAccount(accountId = accountId, userName = s"$firstName $lastName", funds = 1000): AccountCommand).asJson
     )
 
     val amountsWithIds = amounts.map((_, ActionId.random(), UUID.randomUUID()))
@@ -112,17 +106,12 @@ object App {
         builder.addAction(
           actionId,
           constants.accountActionType,
-          new ActionCommand(
-            CommandId.random(),
-            (AccountCommand.ReserveFunds(accountId = accountId,
-                                         reservationId = resId,
-                                         description = s"res-${resId.toString.take(4)}",
-                                         amount = amount): AccountCommand).asJson
-          ),
-          new ActionCommand(
-            CommandId.random(),
-            (AccountCommand
-              .CancelReservation(accountId = accountId, reservationId = resId): AccountCommand).asJson)
+          (AccountCommand.ReserveFunds(accountId = accountId,
+                                       reservationId = resId,
+                                       description = s"res-${resId.toString.take(4)}",
+                                       amount = amount): AccountCommand).asJson,
+          (AccountCommand
+            .CancelReservation(accountId = accountId, reservationId = resId): AccountCommand).asJson
         )
     }
 
@@ -131,21 +120,16 @@ object App {
         builder.addAction(
           ActionId.random(),
           constants.accountActionType,
-          new ActionCommand(
-            CommandId.random(),
-            (AccountCommand.ConfirmReservation(accountId = accountId,
-                                               reservationId = resId,
-                                               finalAmount = amount + adjustment): AccountCommand).asJson)
+          (AccountCommand.ConfirmReservation(accountId = accountId,
+                                             reservationId = resId,
+                                             finalAmount = amount + adjustment): AccountCommand).asJson
         )
     }
 
     val testAsyncInvoke: SubSaga[Json] = builder.addAction(
       ActionId.random(),
       "async_test_action_type",
-      new ActionCommand(
-        CommandId.random(),
-        s"Hello World, time is: ${LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}".asJson)
-    )
+      s"Hello World, time is: ${LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}".asJson)
 
     val v: HttpRequest[Key, String] = HttpRequest.ofWithBody[Key, String](
       Key("fx"),
@@ -158,14 +142,7 @@ object App {
     implicit val encoder: Encoder[HttpRequest[Key, String]] =
       HttpClient.httpRequest[Key, String]._1
 
-    val testHttpInvoke: SubSaga[Json] = builder.addAction(
-      ActionId.random(),
-      "http_action_type",
-      new ActionCommand(
-        CommandId.random(),
-        v.asJson
-      )
-    )
+    val testHttpInvoke: SubSaga[Json] = builder.addAction(ActionId.random(), "http_action_type", v.asJson)
 
     testAsyncInvoke
       .andThen(testHttpInvoke)


### PR DESCRIPTION
This is required for https://github.com/simplesourcing/simplesagas/issues/19

An action retry will replace the command Id of an existing action.
This is because actions are idempotent wrt command ids so if we don't do this retries will keep returning failures.
If it's something the saga may change it shouldn't be exposed to the client in the saga definition.